### PR TITLE
Update the requestBody in CreateRoleModal to work with the API

### DIFF
--- a/src/views/administration/accessmanagement/CreateRoleModal.vue
+++ b/src/views/administration/accessmanagement/CreateRoleModal.vue
@@ -39,7 +39,7 @@
       <b-button size="md" variant="secondary" @click="cancel()">
         {{ $t('message.close') }}
       </b-button>
-      <b-button size="md" variant="primary" @click="createUser()">
+      <b-button size="md" variant="primary" @click="createRole()" :disabled="!name">
         {{ $t('message.create') }}
       </b-button>
     </template>
@@ -68,13 +68,14 @@ export default {
     };
   },
   methods: {
-    createUser() {
+    createRole() {
       let url = `${this.$api.BASE_URL}/${this.$api.URL_ROLE}`;
+      const requestBody = {
+        name: this.name,
+        permissions: this.permissions.map((permission) => permission.name),
+      };
       this.axios
-        .put(url, {
-          name: this.name,
-          permissions: this.permissions,
-        })
+        .put(url, requestBody)
         .then((response) => {
           this.$emit('refreshTable');
           this.$toastr.s(this.$t('admin.role_created'));
@@ -99,10 +100,7 @@ export default {
       this.$root.$emit('bv::show::modal', 'selectPermissionModal');
     },
     updatePermissionSelection(selections) {
-      for (let i = 0; i < selections.length; i++) {
-        let selection = selections[i];
-        this.permissions.push(selection);
-      }
+      this.permissions = selections;
     },
   },
 };


### PR DESCRIPTION
### Description

Modified the CreateRoleModal requestBody to send only a role name and the permissions' names to the API

### Addressed Issue

<!-- REQUIRED
    Reference the issue addressed by this PR, e.g. `#1234`.
    Use keywords to signal that this PR resolves the issue,
    causing the issue to be closed automatically when the PR is merged:
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

### Additional Details

<!-- OPTIONAL
    If desired, share more technical details about the change here.
    Elaborating on why you implemented the change the way you did can be super helpful to the reviewer.
    Did you consider other solutions? Any problems you ran into along the way?

    Providing screenshots, GIFs or even short clips of the new behavior is a great way to demonstrate
    the change to other community members.
-->

### Checklist

<!-- REQUIRED
    Mark items in this list as done by adding a `x` between the square brackets.
    Non-applicable items may be marked as such by surrounding their text with tildes (`~`).

    This is not meant to be a strict to-do list. If you're unsure about anything,
    just leave it empty for now. The maintainers are happy to assist you in figuring it out!
-->

- [ ] I have read and understand the [contributing guidelines](https://github.com/DependencyTrack/hyades/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] This PR introduces new or alters existing behavior, and I have updated the [documentation](https://dependencytrack.github.io/hyades/latest/development/documentation/) accordingly
